### PR TITLE
Existing market order check fix, rampart planning near exits fix

### DIFF
--- a/src/international/internationalManager.ts
+++ b/src/international/internationalManager.ts
@@ -100,7 +100,6 @@ export class InternationalManager {
         let bestOrder: Order
 
         for (const order of orders) {
-
             if (order.price <= minPrice) continue
 
             if (order.price > (bestOrder ? bestOrder.price : 0)) bestOrder = order
@@ -212,7 +211,7 @@ export class InternationalManager {
 
             // If the order is inactive (it likely has 0 remaining amount)
 
-            if (!order.active) continue
+            if (order.remainingAmount == 0) continue
 
             // If there is foundation for this structure, create it
 

--- a/src/room/construction/rampartPlanner.ts
+++ b/src/room/construction/rampartPlanner.ts
@@ -61,11 +61,11 @@ export function rampartPlanner(room: Room) {
             if (room.tileCoords[packXY(0, y + 1)] === EXIT) room.tileCoords[packXY(1, y)] = TO_EXIT
 
             if (room.tileCoords[packXY(roomDimensions - 1, y - 1)] === EXIT)
-                room.tileCoords[packXY(roomDimensions - 3, y)] = TO_EXIT
+                room.tileCoords[packXY(roomDimensions - 2, y)] = TO_EXIT
             if (room.tileCoords[packXY(roomDimensions - 1, y)] === EXIT)
-                room.tileCoords[packXY(roomDimensions - 3, y)] = TO_EXIT
+                room.tileCoords[packXY(roomDimensions - 2, y)] = TO_EXIT
             if (room.tileCoords[packXY(roomDimensions - 1, y + 1)] === EXIT)
-                room.tileCoords[packXY(roomDimensions - 3, y)] = TO_EXIT
+                room.tileCoords[packXY(roomDimensions - 2, y)] = TO_EXIT
         }
 
         let x = 1
@@ -76,11 +76,11 @@ export function rampartPlanner(room: Room) {
             if (room.tileCoords[packXY(x + 1, 0)] === EXIT) room.tileCoords[packXY(x, 1)] = TO_EXIT
 
             if (room.tileCoords[packXY(x - 1, roomDimensions - 1)] === EXIT)
-                room.tileCoords[packXY(x, roomDimensions - 3)] = TO_EXIT
+                room.tileCoords[packXY(x, roomDimensions - 2)] = TO_EXIT
             if (room.tileCoords[packXY(x, roomDimensions - 1)] === EXIT)
-                room.tileCoords[packXY(x, roomDimensions - 3)] = TO_EXIT
+                room.tileCoords[packXY(x, roomDimensions - 2)] = TO_EXIT
             if (room.tileCoords[packXY(x + 1, roomDimensions - 1)] === EXIT)
-                room.tileCoords[packXY(x, roomDimensions - 3)] = TO_EXIT
+                room.tileCoords[packXY(x, roomDimensions - 2)] = TO_EXIT
         }
 
         // mark Border Tiles as not usable
@@ -678,7 +678,6 @@ export function rampartPlanner(room: Room) {
         // So long as there is a pos in path with an index of onboardingIndex
 
         while (path[onboardingIndex]) {
-
             // Get the pos in path with an index of onboardingIndex
 
             const packedPos = pack(path[onboardingIndex])


### PR DESCRIPTION
Appears orders are in an inactive state in the tick they are first placed. As such, when inactive orders are skipped when creating `_myOrders`, new orders are also skipped causing the bot to enter a second order. So `orders.remainingAmount ==  0` is a better check to prevent this.