### PR TITLE
OPTIMIZE call of ccp() only on new rcl or room attack.

### DIFF
--- a/src/room/construction/constructionFunctions.ts
+++ b/src/room/construction/constructionFunctions.ts
@@ -18,9 +18,17 @@ Room.prototype.remoteConstructionPlacement = function () {}
 Room.prototype.communeConstructionPlacement = function () {
     if (!this.memory.PC) return
 
-    // Only run every x ticks or if there are builders (temporary fix)
+    // Only run if not all cs got placed for this rcl or the room is under attack
 
-    if (!this.myCreeps.builder.length && !randomTick(200)) return
+    if (
+        this.memory.PCL &&
+        this.memory.PCL === this.controller.level &&
+        this.enemyCreeps.filter(function (creep) {
+            return !creep.isOnExit
+        }).length === 0 &&
+        !randomTick(200)
+    )
+        return
 
     // If the construction site count is at its limit, stop
 
@@ -112,6 +120,10 @@ Room.prototype.communeConstructionPlacement = function () {
             }
         }
     }
+
+    // If no more cs got placed set the placing cpmpleted for this rlc
+
+    if (placed === 0) this.memory.PCL = this.controller.level
 
     // If visuals are enabled, visually connect roads
 

--- a/src/room/construction/constructionManager.ts
+++ b/src/room/construction/constructionManager.ts
@@ -11,7 +11,7 @@ export function constructionManager(room: Room) {
     // If CPU logging is enabled, get the CPU used at the start
 
     if (Memory.CPULogging) var managerCPUStart = Game.cpu.getUsed()
-/*
+    /*
     // Testing
 
     delete room.memory.PC
@@ -29,15 +29,17 @@ export function constructionManager(room: Room) {
         const centerUpgradePos = room.centerUpgradePos
         if (!centerUpgradePos) return
 
+        const controllerContainer = room.controllerContainer
         if (room.controller.level >= 5) {
-            const controllerContainer = room.controllerContainer
             if (controllerContainer) controllerContainer.destroy()
 
-            room.createConstructionSite(centerUpgradePos, STRUCTURE_LINK)
+            const controllerLink = room.controllerLink
+            if (!controllerLink) room.createConstructionSite(centerUpgradePos, STRUCTURE_LINK)
+
             return
         }
 
-        room.createConstructionSite(centerUpgradePos, STRUCTURE_CONTAINER)
+        if (!controllerContainer) room.createConstructionSite(centerUpgradePos, STRUCTURE_CONTAINER)
     }
 
     room.clearOtherStructures()

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1479,6 +1479,11 @@ declare global {
         PC: boolean
 
         /**
+         * Placing completed for controler level. Set the rcl if all cs has been placed for the room
+         */
+        PCL: number
+
+        /**
          * Remote Planned, wether or not remote planning has been completed for the room
          */
         RP: boolean


### PR DESCRIPTION
The idea behind this is to take care better of the CPU spikes from remoteConstructionPlacement.
It calls the function only, if the room get a higher rcl or if the room get attack.
If all cs got placed for the rcl i set the new memory.PCL to the current rcl.