### PR TITLE
Update sourceHarvester.ts to make harvester contribute into container construction site

### DIFF
--- a/src/room/creeps/roleManagers/commune/sourceHarvester.ts
+++ b/src/room/creeps/roleManagers/commune/sourceHarvester.ts
@@ -39,7 +39,26 @@ export class SourceHarvester extends Creep {
         const source = this.room.roomManager.communeSources[this.memory.SI]
 
         if (getRange(this.pos, source.pos) <= 1) {
-            this.advancedHarvestSource(source)
+            const constructionSite = this.pos.findInRange(FIND_MY_CONSTRUCTION_SITES, 1, {
+                filter: (structure) => {
+                    return structure.structureType === STRUCTURE_CONTAINER;
+                },
+            })[0];
+
+            // Check if there is container construction site placed and help building it 25% of the time
+
+            if (constructionSite) {
+
+                // Roll 25% dice and only build if creep is full othervise dropmine
+
+                if (Math.random() < 0.25 && this.store.getCapacity() - this.nextStore.energy == 0) {
+                    this.build(constructionSite);
+                } else {
+                    this.advancedHarvestSource(source);
+                }
+            } else {
+                this.advancedHarvestSource(source);
+            }
         }
     }
 

--- a/src/room/creeps/roleManagers/commune/sourceHarvester.ts
+++ b/src/room/creeps/roleManagers/commune/sourceHarvester.ts
@@ -49,7 +49,7 @@ export class SourceHarvester extends Creep {
 
             if (constructionSite) {
 
-                // Roll 10% dice and only build if creep is full othervise dropmine
+                // Roll 10% dice and only build if creep is full otherwise keep dropmining
 
                 if (Math.random() < 0.1 && this.store.getCapacity() - this.nextStore.energy == 0) {
                     this.build(constructionSite);

--- a/src/room/creeps/roleManagers/commune/sourceHarvester.ts
+++ b/src/room/creeps/roleManagers/commune/sourceHarvester.ts
@@ -45,13 +45,13 @@ export class SourceHarvester extends Creep {
                 },
             })[0];
 
-            // Check if there is container construction site placed and help building it 25% of the time
+            // Check if there is container construction site placed and help building it 10% of the time
 
             if (constructionSite) {
 
-                // Roll 25% dice and only build if creep is full othervise dropmine
+                // Roll 10% dice and only build if creep is full othervise dropmine
 
-                if (Math.random() < 0.25 && this.store.getCapacity() - this.nextStore.energy == 0) {
+                if (Math.random() < 0.1 && this.store.getCapacity() - this.nextStore.energy == 0) {
                     this.build(constructionSite);
                 } else {
                     this.advancedHarvestSource(source);


### PR DESCRIPTION
Tested live shard2:
https://screeps.com/a/#!/history/shard2/E14S53?t=47319200
Source container at [26, 38]

Removed container and verified intended behavior:
- Random attempt at 10% chance to build container if creep is full of energy

Note: tested with 50% and 25% and at those rates it got counterproductive since dropped energypile was not being maintained well enough. Might need more testing to find perfect buildrate. Or additionally might be good idea to add check for energypile amount and limit building based off it.