### PR TITLE
Add Game.time to stats

### DIFF
--- a/src/international/statsManager.ts
+++ b/src/international/statsManager.ts
@@ -369,6 +369,7 @@ export class StatsManager {
         Memory.stats = {
             lastReset: 0,
             tickLength: 0,
+            lastTick: 0,
             lastTickTimestamp: 0,
             resources: {
                 pixels: 0,
@@ -419,6 +420,7 @@ export class StatsManager {
         Memory.stats.lastReset = global.lastReset
         Memory.stats.tickLength = timestamp - Memory.stats.lastTickTimestamp
         Memory.stats.lastTickTimestamp = timestamp
+        Memory.stats.lastTick = Game.time
         Memory.stats.constructionSiteCount = global.constructionSitesCount || 0
 
         Memory.stats.resources = {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -712,6 +712,7 @@ declare global {
         lastReset: number
 
         lastTickTimestamp: number
+        lastTick: number
         tickLength: number
 
         communeCount: number


### PR DESCRIPTION
This will allow grafana graphs with tick number as time scale.
It is more statisticly correct than datetime scale since tick rate may vary.