### PR TITLE
feat: use rollup-plugin-screeps-ss3

### DIFF
--- a/.screeps.yaml.example
+++ b/.screeps.yaml.example
@@ -3,17 +3,14 @@ servers:
     host: screeps.com
     secure: true
     token: "00000000-0a0a-0a00-000a-a0000a0000a0"
-    branch: "default"
   pserver:
     host: 127.0.0.1
     port: 21025
     secure: false
     username: "your username (case sensitive!)"
     password: "your password"
-    branch: "default"
   perf:
     host: 127.0.0.1
     username: "W1N1"
     password: "password"
-    branch: "default"
 # add your own servers

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
                 "prettier": "^2.3.2",
                 "rollup": "^2.56.2",
                 "rollup-plugin-clear": "^2.0.7",
-                "rollup-plugin-screeps": "^1.0.1",
+                "rollup-plugin-screeps-ss3": "^1.1.1",
                 "rollup-plugin-terser": "^7.0.2",
                 "rollup-plugin-typescript2": "^0.30.0",
                 "screeps-grafana": "^2.2.2",
@@ -54,8 +54,7 @@
                 "ts-jest": "^27.0.5",
                 "ts-node": "^10.2.0",
                 "tsconfig-paths": "^3.10.1",
-                "typescript": "4.4",
-                "yaml": "^1.10.2"
+                "typescript": "4.4"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -4544,8 +4543,9 @@
         },
         "node_modules/git-rev-sync": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/git-rev-sync/-/git-rev-sync-2.1.0.tgz",
+            "integrity": "sha512-qZWv4D3GBm9sHEq5Jvc2rGuwQbz52mJoNAhe/zZS+rlwft7n8BGAG0QCgXt6m+jxn82IwlpOT3UXY81LkFJufA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "escape-string-regexp": "1.0.5",
                 "graceful-fs": "4.1.15",
@@ -4554,8 +4554,9 @@
         },
         "node_modules/git-rev-sync/node_modules/graceful-fs": {
             "version": "4.1.15",
-            "dev": true,
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+            "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+            "dev": true
         },
         "node_modules/glob": {
             "version": "7.2.3",
@@ -4886,8 +4887,9 @@
         },
         "node_modules/interpret": {
             "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.10"
             }
@@ -8405,6 +8407,8 @@
         },
         "node_modules/rechoir": {
             "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+            "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
             "dev": true,
             "dependencies": {
                 "resolve": "^1.1.6"
@@ -8552,13 +8556,14 @@
                 "rimraf": "^2.6.2"
             }
         },
-        "node_modules/rollup-plugin-screeps": {
-            "version": "1.0.1",
+        "node_modules/rollup-plugin-screeps-ss3": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-screeps-ss3/-/rollup-plugin-screeps-ss3-1.1.1.tgz",
+            "integrity": "sha512-DWJuaCm41WoN71KoNdYprg/e2DVeYgwCUbsLFdJGyk5jUyzolJLt3zbxGoVWtriQC2IFFm8r8JU3sKp6aAvGvw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "git-rev-sync": "^2.0.0",
-                "screeps-api": "^1.11.0"
+                "screeps-api": "^1.16.0"
             }
         },
         "node_modules/rollup-plugin-terser": {
@@ -8884,8 +8889,9 @@
         },
         "node_modules/shelljs": {
             "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+            "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "dependencies": {
                 "glob": "^7.0.0",
                 "interpret": "^1.0.0",
@@ -9827,15 +9833,6 @@
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
-        },
-        "node_modules/yaml": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 6"
-            }
         },
         "node_modules/yamljs": {
             "version": "0.3.0",
@@ -12777,6 +12774,8 @@
         },
         "git-rev-sync": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/git-rev-sync/-/git-rev-sync-2.1.0.tgz",
+            "integrity": "sha512-qZWv4D3GBm9sHEq5Jvc2rGuwQbz52mJoNAhe/zZS+rlwft7n8BGAG0QCgXt6m+jxn82IwlpOT3UXY81LkFJufA==",
             "dev": true,
             "requires": {
                 "escape-string-regexp": "1.0.5",
@@ -12786,6 +12785,8 @@
             "dependencies": {
                 "graceful-fs": {
                     "version": "4.1.15",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+                    "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
                     "dev": true
                 }
             }
@@ -12988,6 +12989,8 @@
         },
         "interpret": {
             "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
             "dev": true
         },
         "is-arrayish": {
@@ -15227,6 +15230,8 @@
         },
         "rechoir": {
             "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+            "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
             "dev": true,
             "requires": {
                 "resolve": "^1.1.6"
@@ -15313,12 +15318,14 @@
                 "rimraf": "^2.6.2"
             }
         },
-        "rollup-plugin-screeps": {
-            "version": "1.0.1",
+        "rollup-plugin-screeps-ss3": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-screeps-ss3/-/rollup-plugin-screeps-ss3-1.1.1.tgz",
+            "integrity": "sha512-DWJuaCm41WoN71KoNdYprg/e2DVeYgwCUbsLFdJGyk5jUyzolJLt3zbxGoVWtriQC2IFFm8r8JU3sKp6aAvGvw==",
             "dev": true,
             "requires": {
                 "git-rev-sync": "^2.0.0",
-                "screeps-api": "^1.11.0"
+                "screeps-api": "^1.16.0"
             }
         },
         "rollup-plugin-terser": {
@@ -15542,6 +15549,8 @@
         },
         "shelljs": {
             "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+            "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
             "dev": true,
             "requires": {
                 "glob": "^7.0.0",
@@ -16153,12 +16162,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
-        },
-        "yaml": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
             "dev": true
         },
         "yamljs": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "prettier": "^2.3.2",
         "rollup": "^2.56.2",
         "rollup-plugin-clear": "^2.0.7",
-        "rollup-plugin-screeps": "^1.0.1",
+        "rollup-plugin-screeps-ss3": "^1.1.1",
         "rollup-plugin-terser": "^7.0.2",
         "rollup-plugin-typescript2": "^0.30.0",
         "screeps-grafana": "^2.2.2",
@@ -72,8 +72,7 @@
         "ts-jest": "^27.0.5",
         "ts-node": "^10.2.0",
         "tsconfig-paths": "^3.10.1",
-        "typescript": "4.4",
-        "yaml": "^1.10.2"
+        "typescript": "4.4"
     },
     "dependencies": {
         "base32768": "^3.0.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,29 +2,12 @@ import typescript from 'rollup-plugin-typescript2'
 import resolve from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
 import clear from 'rollup-plugin-clear'
-import screeps from 'rollup-plugin-screeps'
-import { terser } from 'rollup-plugin-terser'
-import yaml from 'yaml'
-import { readFileSync } from 'fs'
+import screeps from 'rollup-plugin-screeps-ss3'
 
-let cfg
 const dest = process.env.DEST
 if (!dest) {
     console.log('No destination specified - code will be compiled but not uploaded')
-} else {
-    cfg = (yaml.parse(readFileSync('.screeps.yaml', { encoding: 'utf8' })).servers || {})[dest]
-    if (cfg == null) throw new Error('Invalid upload destination')
-    cfg.hostname = cfg.host
-    cfg.port = cfg.port || (cfg.secure ? 443 : 21025)
-    cfg.host = `${cfg.host}:${cfg.port}`
-    cfg.email = cfg.username
-    cfg.protocol = cfg.secure ? 'https' : 'http'
-    cfg.path = cfg.path || '/'
-    cfg.branch = cfg.branch || 'auto'
 }
-
-const shouldUglify = cfg && cfg.uglify
-if (cfg) delete cfg.uglify
 
 export default {
     input: 'src/main.ts',
@@ -38,8 +21,7 @@ export default {
         clear({ targets: ['dist'] }),
         commonjs(),
         resolve({ rootDir: 'src' }),
-        shouldUglify && terser(),
         typescript({ tsconfig: './tsconfig.json' }),
-        screeps({ config: cfg, dryRun: cfg == null }),
+        screeps({ server: dest, branch: 'default', dryRun: !dest }),
     ],
 }


### PR DESCRIPTION
Single negative point, screeps-api-node does not expose additional values like `branch` in `.screeps.yaml`

So the branch is only configurable with `screeps({ branch: 'a-branch' })` or env var `$SCREEPS_BRANCH` if none is provided, the branch uses the current git branch name (as `"branch": "auto"` in `screeps.json`)

Current behaviour is to use `default` branch in any case