### PR TITLE
fix: fix #783 remote container construction sites not beeing handled

### DIFF
--- a/src/room/creeps/roleManagers/remote/remoteSourceHarvester.ts
+++ b/src/room/creeps/roleManagers/remote/remoteSourceHarvester.ts
@@ -383,7 +383,8 @@ export class RemoteHarvester extends Creep {
 
   buildContainer(): number {
     // Don't build new remote containers until we can reserve the room
-    if (!CommuneUtils.shouldRemoteContainers(this.room)) return Result.noAction
+    // if (!CommuneUtils.shouldRemoteContainers(this.room)) return Result.noAction
+    if (!this.room.controller.reservation || this.room.controller.reservation.username !== Memory.me) return Result.noAction
 
     // Make sure we're a bit ahead source regen time
 


### PR DESCRIPTION
Don't know what the history behind this is but the current check for available amout of storage in spawns + extensions doesn't make any sense for a remote. I've switched that to just check if the room is reserved. This works well for me.

fixes #783 