### PR TITLE
feat: add role names visualization to FlagManager

### DIFF
--- a/src/international/flags/flags.ts
+++ b/src/international/flags/flags.ts
@@ -48,6 +48,76 @@ export class FlagManager {
     flag.setColor(COLOR_GREEN)
     room.roomManager.roomVisualsManager.internationalDataVisuals()
   }
+  private roleNames(flagName: string, flagNameParts: string[]) {
+    const flag = Game.flags[flagName]
+    const roomName = flagNameParts[1] || flag.pos.roomName
+    const room = Game.rooms[roomName]
+    if (!room) {
+      flag.setColor(COLOR_RED)
+      return
+    }
+
+    flag.setColor(COLOR_GREEN)
+
+    // Sorry for hardcode but CreepRoles is a type! :p
+    const ROLES = [
+      'sourceHarvester',
+      'hauler',
+      'requestHauler',
+      'controllerUpgrader',
+      'builder',
+      'maintainer',
+      'mineralHarvester',
+      'hubHauler',
+      'fastFiller',
+      'meleeDefender',
+      'rangedDefender',
+      'remoteSourceHarvester',
+      'remoteReserver',
+      'remoteDefender',
+      'remoteCoreAttacker',
+      'remoteDismantler',
+      'remoteBuilder',
+      'scout',
+      'claimer',
+      'vanguard',
+      'allyVanguard',
+      'antifaRangedAttacker',
+      'antifaAttacker',
+      'antifaHealer',
+      'antifaDismantler',
+      'antifaDowngrader',
+    ]
+
+    const height = 3 + ROLES.length
+    const data = ROLES.map(role => [role, ROLES.indexOf(role)])
+    const headers = ['Role', 'index']
+    
+    Dashboard({
+      config: {
+        room: room.roomManager.room.name,
+      },
+      widgets: [
+        {
+          pos: {
+            x: 1,
+            y: 1,
+          },
+          width: 20,
+          height,
+          widget: Rectangle({
+            data: Table(() => ({
+              data,
+              config: {
+                label: 'Creep Roles',
+                headers,
+              },
+            })),
+          }),
+        },
+      ],
+    })
+  }
 
   private incomingTransactions(flagName: string, flagNameParts: string[]) {
     const flag = Game.flags[flagName]


### PR DESCRIPTION
got sick and tired of going back between editor to hover over creep role index and creep info screen.

Adds Flag 'roleNames' to assist debug.
contains hardcoded creep role list.


![image](https://github.com/The-International-Screeps-Bot/The-International-Open-Source/assets/30669146/173f123d-e52c-47c0-ac38-694b1b6e3ed9)
